### PR TITLE
Develop

### DIFF
--- a/src/Fabs/LINQ/LINQ.php
+++ b/src/Fabs/LINQ/LINQ.php
@@ -115,11 +115,12 @@ class LINQ
     }
 
     /**
+     * @param int $sort_flags
      * @return LINQ
      */
-    public function distinct()
+    public function distinct($sort_flags = SORT_REGULAR)
     {
-        $this->data = array_unique($this->data);
+        $this->data = array_unique($this->data, $sort_flags);
         return $this;
     }
 


### PR DESCRIPTION
[array_unique](http://php.net/array-unique
)

> 5.2.10 | Changed the default value of sort_flags back to SORT_STRING.
